### PR TITLE
[fix] Separates bcrypt hashing functions in separate file to resolve circular import.

### DIFF
--- a/app/controllers/AuthController.py
+++ b/app/controllers/AuthController.py
@@ -1,7 +1,8 @@
 from fastapi import HTTPException, status
 from sqlmodel import Session
 
-from app.utils.auth import verify_password, generate_access_token, generate_refresh_token, get_hash
+from app.utils.hashing import get_hash, verify_password
+from app.utils.auth import generate_access_token, generate_refresh_token
 from app.models.User import User, UserLogin
 from app.models.Auth import Token
 from app.models.RefreshToken import RefreshToken

--- a/app/controllers/UserController.py
+++ b/app/controllers/UserController.py
@@ -1,6 +1,6 @@
 from fastapi import HTTPException, status
 from sqlmodel import Session
-from app.utils.auth import get_hash
+from app.utils.hashing import get_hash
 
 import sqlmodel as sql
 

--- a/app/routes/InstitutionType.py
+++ b/app/routes/InstitutionType.py
@@ -4,10 +4,12 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from app.controllers import InstitutionTypeController
 from app.db import get_session
 from app.models.InstitutionType import InstitutionTypeCreate, InstitutionTypeUpdate, InstitutionType
+from app.utils.auth import get_admin_user
 
 router = APIRouter(
   prefix="/institution-type",
   tags=["institution-type"],
+  dependencies=[Depends(get_admin_user)],
   responses={
     status.HTTP_404_NOT_FOUND: {"description": "Institution type not found"},
     status.HTTP_400_BAD_REQUEST: {"description": "Invalid request data"},

--- a/app/utils/auth.py
+++ b/app/utils/auth.py
@@ -27,14 +27,6 @@ refresh_token_expire_days = float(os.getenv("REFRESH_TOKEN_EXPIRE_DAYS"))
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/token")
 
-def verify_password(plain_password, hashed_password):
-    return bcrypt.checkpw(plain_password.encode('utf-8'), hashed_password.encode('utf-8'))
-
-def get_hash(password: str):
-    pwd_bytes = password.encode('utf-8')
-    hashed_password = bcrypt.hashpw(password=pwd_bytes, salt=bcrypt.gensalt())
-    return hashed_password
-
 def generate_access_token(data: dict, expires_delta: timedelta | None = None):
     to_encode = data.copy()
     if expires_delta:

--- a/app/utils/hashing.py
+++ b/app/utils/hashing.py
@@ -1,0 +1,10 @@
+
+import bcrypt
+
+def verify_password(plain_password, hashed_password):
+    return bcrypt.checkpw(plain_password.encode('utf-8'), hashed_password.encode('utf-8'))
+
+def get_hash(password: str):
+    pwd_bytes = password.encode('utf-8')
+    hashed_password = bcrypt.hashpw(password=pwd_bytes, salt=bcrypt.gensalt())
+    return hashed_password


### PR DESCRIPTION


Se separaron las funciones get_hash() y verify_password() a el archivo utils/hashing.py para evitar circular imoprt.

Había un circular import entre auth.py y UserController.py con la función get_hash(), pq UserController ocupaba user.password = get_hash(user.password) de auth.py en la function create_user() para hashear passwd antes de guardarla en base de datos y auth.py ocupaba UserController.get_by_username(token_data.username, session) para obtener usuario en la función get_current_user().

Esto estaba arrojando error al agregar dependencies=[Depends(get_admin_user)], al router en routes/InstitutionType.py.
