### PR TITLE
[fix] user creation: enforces uniqueness of username in addition to email

### DIFF
--- a/app/controllers/UserController.py
+++ b/app/controllers/UserController.py
@@ -21,13 +21,15 @@ def create_user(user: UserCreate, session: Session):
         HTTPException: 409 Conflict if email is already registered.
     """
     existing_user = session.exec(
-        sql.select(User).where(User.email == user.email)
+        sql.select(User).where(
+            (User.email == user.email) | (User.username == user.username)
+        )
     ).first()
     
     if existing_user:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail="Email already registered"
+            detail="Email or username is already in use"
         )
     
     # Hash de la contraseña


### PR DESCRIPTION
Agrega validación que username no exista al crear usuario.
Probado con username y mail:
<img width="689" alt="image" src="https://github.com/user-attachments/assets/fd8e8250-5c5e-49ec-9c69-de257589849d" />
